### PR TITLE
Add panic recovery to FSM event processing

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -83,7 +83,15 @@ func (f *FSM[T]) ProcessEvent(ctx context.Context, t Target[T]) (Target[T], erro
 	return f.processEvent(ctx, t)
 }
 
-func (f *FSM[T]) processEvent(ctx context.Context, t Target[T]) (Target[T], error) {
+func (f *FSM[T]) processEvent(ctx context.Context, t Target[T]) (nt Target[T], err error) {
+	defer func() {
+		if err := recover(); err != nil {
+			f.l.Error("panic in FSM", zap.Any("err", err))
+
+			nt = t
+		}
+	}()
+
 	var (
 		ok bool
 	)


### PR DESCRIPTION
This ensures the FSM does not crash when a panic occurs during event processing. Instead, the error is logged, and the FSM returns to the given target, maintaining stability.